### PR TITLE
Improve typings and add tests

### DIFF
--- a/src/mapfile2js/parse/checkBlockKey.spec.ts
+++ b/src/mapfile2js/parse/checkBlockKey.spec.ts
@@ -1,0 +1,55 @@
+import { checkBlockKey } from './checkBlockKey';
+
+const expectedReturnShape = {
+  isBlockKey: expect.any(Boolean),
+  isBlockLine: expect.any(Boolean)
+}
+
+describe('checkBlockKey', () => {
+  it('is defined', () => {
+    expect(checkBlockKey).toBeDefined();
+  });
+  it('is a function', () => {
+    expect(checkBlockKey).toBeInstanceOf(Function);
+  });
+  it('returns a line object', () => {
+    const got = checkBlockKey({
+      isKeyOnly: true,
+      key: 'MAP',
+      value: ''
+    });
+    expect(got).toMatchObject(expectedReturnShape);
+  });
+  it('detects key only blocks', () => {
+    const got = checkBlockKey({
+      isKeyOnly: true,
+      key: 'MAP',
+      value: ''
+    });
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isBlockKey).toBe(true);
+    expect(got.isBlockLine).toBe(false);
+  });
+  it('detects single line blocks', () => {
+    const got = checkBlockKey({
+      isKeyOnly: false,
+      key: 'PATTERN',
+      value: '10 10 END'
+    });
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isBlockKey).toBe(true);
+    expect(got.isBlockLine).toBe(true);
+  });
+  it('does not report END as block', () => {
+    const got = checkBlockKey({
+      isKeyOnly: true,
+      key: 'END',
+      value: ''
+    });
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isBlockKey).toBe(false);
+    expect(got.isBlockLine).toBe(false);
+  });
+
+  // TODO add test for PROJECTION / "init=epsg:4326" special handling
+});

--- a/src/mapfile2js/parse/checkBlockKey.ts
+++ b/src/mapfile2js/parse/checkBlockKey.ts
@@ -1,13 +1,21 @@
+import { KeyValueLineObject } from './checkKeyValue';
+
+
+interface BlockObject {
+  isBlockKey: boolean;
+  isBlockLine: boolean;
+}
+
 /**
  *
  * @param {object} lineObject
  * @returns {object} line object.
  */
-export function checkBlockKey(lineObject: any): object {
-  const lo: any = {};
-
-  lo.isBlockKey = false;
-  lo.isBlockLine = false;
+export function checkBlockKey(lineObject: KeyValueLineObject): BlockObject {
+  const lo: BlockObject = {
+    isBlockKey: false,
+    isBlockLine: false
+  };
 
   if (lineObject.isKeyOnly) {
     // END is no block

--- a/src/mapfile2js/parse/checkComment.spec.ts
+++ b/src/mapfile2js/parse/checkComment.spec.ts
@@ -1,0 +1,41 @@
+import { checkComment } from './checkComment';
+
+const expectedReturnShape = {
+  includesComment: expect.any(Boolean),
+  comment: expect.any(String),
+  contentWithoutComment: expect.any(String)
+}
+
+describe('checkComment', () => {
+  it('is defined', () => {
+    expect(checkComment).toBeDefined();
+  });
+  it('is a function', () => {
+    expect(checkComment).toBeInstanceOf(Function);
+  });
+  it('returns a line object', () => {
+    const got = checkComment('');
+    expect(got).toMatchObject(expectedReturnShape);
+  });
+  it('detects an inline comment', () => {
+    const got = checkComment('END # foo comment');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.includesComment).toEqual(true);
+    expect(got.comment).toEqual('foo comment');
+    expect(got.contentWithoutComment).toEqual('END');
+  });
+  it('works on lines with hex colors wo/ an inline comment', () => {
+    const got = checkComment('COLOR "#BADA55"');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.includesComment).toEqual(false);
+    expect(got.comment).toEqual('');
+    expect(got.contentWithoutComment).toEqual('COLOR "#BADA55"');
+  });
+  it('works on lines with hex colors w/ an inline comment', () => {
+    const got = checkComment('COLOR "#DEADBEEF" # baz comment');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.includesComment).toEqual(true);
+    expect(got.comment).toEqual('baz comment');
+    expect(got.contentWithoutComment).toEqual('COLOR "#DEADBEEF"');
+  });
+});

--- a/src/mapfile2js/parse/checkComment.ts
+++ b/src/mapfile2js/parse/checkComment.ts
@@ -1,12 +1,18 @@
 const regExpHexColor = new RegExp('["\']#[0-9a-f]{6}["\']|["\']#[0-9a-f]{3}["\']', 'gi');
 
+interface LineObject {
+  includesComment: boolean;
+  comment: string;
+  contentWithoutComment: string;
+}
+
 /**
  *
  * @param {string} line A line of mapfile
- * @returns {object} A line object
+ * @returns {LineObject} A line object
  */
-export function checkComment(line: string): object {
-  const lineObject = {
+export function checkComment(line: string): LineObject {
+  const lineObject: LineObject = {
     includesComment: false,
     comment: '',
     contentWithoutComment: line,

--- a/src/mapfile2js/parse/checkComment.ts
+++ b/src/mapfile2js/parse/checkComment.ts
@@ -1,4 +1,4 @@
-const regExpHexColor = new RegExp('["\']#[0-9a-f]{6}["\']|["\']#[0-9a-f]{3}["\']', 'gi');
+const regExpHexColor = new RegExp('["\']#[0-9a-f]{6,8}["\']|["\']#[0-9a-f]{3}["\']', 'gi');
 
 interface LineObject {
   includesComment: boolean;

--- a/src/mapfile2js/parse/checkKeyValue.spec.ts
+++ b/src/mapfile2js/parse/checkKeyValue.spec.ts
@@ -1,0 +1,48 @@
+import { checkKeyValue, KeyValueLineObject } from './checkKeyValue';
+
+const expectedReturnShape: KeyValueLineObject = {
+  isKeyOnly: expect.any(Boolean),
+  key: expect.any(String),
+  value: expect.any(String)
+}
+
+describe('checkKeyValue', () => {
+  it('is defined', () => {
+    expect(checkKeyValue).toBeDefined();
+  });
+  it('is a function', () => {
+    expect(checkKeyValue).toBeInstanceOf(Function);
+  });
+  it('returns a KeyValueLineObject', () => {
+    const got = checkKeyValue('');
+    expect(got).toMatchObject(expectedReturnShape);
+  });
+  it('handles key only lines properly', () => {
+    const got = checkKeyValue('MAP');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isKeyOnly).toBe(true);
+    expect(got.key).toBe('MAP');
+    expect(got.value).toBe('');
+  });
+  it('handles key/value lines properly', () => {
+    const got = checkKeyValue('IMAGETYPE PNG');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isKeyOnly).toBe(false);
+    expect(got.key).toBe('IMAGETYPE');
+    expect(got.value).toBe('PNG');
+  });
+  it('removes quotes around most values', () => {
+    const got = checkKeyValue('COLOR "#DEADBEEF"');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isKeyOnly).toBe(false);
+    expect(got.key).toBe('COLOR');
+    expect(got.value).toBe('#DEADBEEF');
+  });
+  it('leaves quotes untouched for EXPRESSION values', () => {
+    const got = checkKeyValue('EXPRESSION "2005"');
+    expect(got).toMatchObject(expectedReturnShape);
+    expect(got.isKeyOnly).toBe(false);
+    expect(got.key).toBe('EXPRESSION');
+    expect(got.value).toBe('"2005"');
+  });
+});

--- a/src/mapfile2js/parse/checkKeyValue.ts
+++ b/src/mapfile2js/parse/checkKeyValue.ts
@@ -6,12 +6,22 @@ function removeQuotes(str: string): string {
   return str;
 }
 
+export interface KeyValueLineObject {
+  isKeyOnly: boolean;
+  key: string;
+  value: string;
+}
+
 /**
  *
  * @param {string} line Line without comment
  */
-export function checkKeyValue(line: string): object {
-  const lineObject: any = {};
+export function checkKeyValue(line: string): KeyValueLineObject {
+  const lineObject: KeyValueLineObject = {
+    isKeyOnly: false,
+    key: '',
+    value: ''
+  };
 
   if (line.match(/\s/)) {
     // Check key value
@@ -23,7 +33,9 @@ export function checkKeyValue(line: string): object {
     lineObject.key = key;
     const value = line.replace(lineParts[0], '').trim();
     // do not mess with expressions, quotes have meaning
-    lineObject.value = key.toUpperCase() === 'EXPRESSION' ? value : removeQuotes(value);
+    lineObject.value = key.toUpperCase() === 'EXPRESSION'
+      ? value
+      : removeQuotes(value);
   } else {
     // key only
     lineObject.isKeyOnly = true;


### PR DESCRIPTION
This PR tries to improve typings of the parser methods a bit and adds a bunch of tests.

Since `npm test` currently fails on master due to unrelated things, the tests herein need to be run e.g. with `jest -t check`; they all pass locally for me.

This also revealed a tiny bug where hexcolors with alpha channel (e.g. `#rrggbbaa`) wouldn't be detected properly. These are allowed according to https://mapserver.org/mapfile/style.html 




 