### PR TITLE
Configurable symbols.sym path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ parser
 
 Writing a Mapfile from a Geostyler-Style object is currently not possible.
 
+### Specify a symbols.sym file
+
+If a symbolset tag is defined in your mapfile, this link will be followed to read symbols.
+If it's not the case a `symbols.sym` should be located from where you call the transformation.
+
+You can set the default path with:
+
+```
+const parser = new MapfileParser();
+parser.symbolsPath = '<a/path/to/symbols.sym>'
+```
+
+Alternatively, if you use this library through a script, you can set the path by adding the 
+command line option: `mapfile-symbols-path=`.
+
 ## Run tests
 
 ```sh

--- a/data/mapfiles/mapserver.map
+++ b/data/mapfiles/mapserver.map
@@ -39,7 +39,7 @@ MAP
     STATUS ON
 
     FONTSET "fonts.conf"
-    SYMBOLSET "symbols.sym"
+    SYMBOLSET "data/mapfiles/symbols.sym"
 
     OUTPUTFORMAT
         NAME jpeg

--- a/src/MapfileStyleParser.spec.ts
+++ b/src/MapfileStyleParser.spec.ts
@@ -35,6 +35,7 @@ describe('MapfileStyleParser implements StyleParser', () => {
 
   beforeEach(() => {
     styleParser = new MapfileStyleParser();
+    styleParser.symbolsPath = './data/mapfiles/symbols.sym';
   });
 
   describe('#readStyle', () => {

--- a/src/MapfileStyleParser.ts
+++ b/src/MapfileStyleParser.ts
@@ -43,6 +43,8 @@ export class MapfileStyleParser implements StyleParser {
 
   title = 'Mapfile Style Parser';
 
+  symbolsPath = `${process.cwd()}/symbols.sym`;
+
   constructor(opts?: ConstructorParams) {
     Object.assign(this, opts);
   }
@@ -881,7 +883,7 @@ export class MapfileStyleParser implements StyleParser {
   readStyle(mapfileString: string): Promise<Style> {
     return new Promise<Style>((resolve, reject) => {
       try {
-        const mapfile: Mapfile = parseMapfile(mapfileString);
+        const mapfile: Mapfile = parseMapfile(mapfileString, this.symbolsPath);
         const mapfileLayers = mapfile.map.layers || [];
         if (mapfileLayers.length > 1) {
           throw new Error('Can not read multiple LAYER in one file. Use method readMultiStyle instead.');
@@ -903,7 +905,7 @@ export class MapfileStyleParser implements StyleParser {
   readMultiStyles(mapfileString: string): Promise<Style[]> {
     return new Promise<Style[]>((resolve, reject) => {
       try {
-        const mapfile: Mapfile = parseMapfile(mapfileString);
+        const mapfile: Mapfile = parseMapfile(mapfileString, this.symbolsPath);
         const mapfileLayers = mapfile.map.layers || [];
         const geoStylerStyles: Style[] = mapfileLayers.map((layer: any) => {
           return this.mapfileLayerToGeoStylerStyle(layer);

--- a/src/mapfile2js/parse/resolveSymbolset.ts
+++ b/src/mapfile2js/parse/resolveSymbolset.ts
@@ -31,21 +31,29 @@ function substituteSymbols(obj: any): void {
  */
 export function resolveSymbolset(mapfile: Mapfile, symbolsPath?: string): Mapfile {
   let symbolsetPath = mapfile.map.symbolset;
+  let symbolsetFrom = 'MapFile SYMBOLSET tag';
 
   if (!symbolsetPath) {
     // Fallback to load the symbols file. Search "mapfile-symbols-path=" in the process args
     // (command line options).
     const processArgs = process.argv.slice(2);
     symbolsetPath = processArgs.find(arg => arg.search('mapfile-symbols-path=') === 0);
+    symbolsetFrom = 'command line argument';
   }
 
   if (!symbolsetPath) {
     // Second fallback to the symbols file. Use the given symbolsPath value.
     symbolsetPath = symbolsPath;
+    symbolsetFrom = 'the "symbolsPath" configuration of the parser.';
   }
   
-  if (!symbolsetPath || !fs.existsSync(symbolsetPath)) {
-    console.error(`Non existent symbolset path: ${symbolsetPath}`);
+  if (!symbolsetPath) {
+    console.error('No symbolset path defined.');
+    return mapfile;
+  }
+
+  if (!fs.existsSync(symbolsetPath)) {
+    console.error(`No file found for symbolset path: ${symbolsetPath} (path taken from ${symbolsetFrom})`);
     return mapfile;
   }
 

--- a/src/mapfile2js/parse/resolveSymbolset.ts
+++ b/src/mapfile2js/parse/resolveSymbolset.ts
@@ -26,19 +26,27 @@ function substituteSymbols(obj: any): void {
 }
 
 /**
- *
  * @param {Mapfile} mapfile Parsed Mapfile Object
+ * @param {string} symbolsPath optional path of the symbols.sym file if no symbolset is defined in the Mapfile.
  */
-export function resolveSymbolset(mapfile: Mapfile): Mapfile {
+export function resolveSymbolset(mapfile: Mapfile, symbolsPath?: string): Mapfile {
   let symbolsetPath = mapfile.map.symbolset;
 
-  // fallback to mapserver defaults if not specified
-  const fallbackPath = `${__dirname}/../../../data/mapfiles/symbols.sym`;
   if (!symbolsetPath) {
-    symbolsetPath = fallbackPath;
-  } else if (!fs.existsSync(symbolsetPath)) {
+    // Fallback to load the symbols file. Search "mapfile-symbols-path=" in the process args
+    // (command line options).
+    const processArgs = process.argv.slice(2);
+    symbolsetPath = processArgs.find(arg => arg.search('mapfile-symbols-path=') === 0);
+  }
+
+  if (!symbolsetPath) {
+    // Second fallback to the symbols file. Use the given symbolsPath value.
+    symbolsetPath = symbolsPath;
+  }
+  
+  if (!symbolsetPath || !fs.existsSync(symbolsetPath)) {
     console.error(`Non existent symbolset path: ${symbolsetPath}`);
-    symbolsetPath = fallbackPath;
+    return mapfile;
   }
 
   // resolve symbolset

--- a/src/mapfile2js/parseMapfile.spec.ts
+++ b/src/mapfile2js/parseMapfile.spec.ts
@@ -7,8 +7,10 @@ describe('parseMapfile', () => {
     expect(parseMapfile).toBeDefined();
   });
   it('can parse a mapfile', () => {
-    const pathToMapfile = `${__dirname}/../../data/mapfiles/mapserver.map`;
-    const mapfile = parseMapfile(fs.readFileSync(pathToMapfile, 'utf8'));
+    const pathToMapfilesDir = `${__dirname}/../../data/mapfiles`;
+    const pathToMapfile = `${pathToMapfilesDir}/mapserver.map`;
+    const pathToSymbols = `${pathToMapfilesDir}/symbols.sym`;
+    const mapfile = parseMapfile(fs.readFileSync(pathToMapfile, 'utf8'), pathToSymbols);
     expect(mapfile).toHaveProperty('map');
   });
 });

--- a/src/mapfile2js/parseMapfile.ts
+++ b/src/mapfile2js/parseMapfile.ts
@@ -128,16 +128,17 @@ function parseContent(content: string): Record<string, unknown> {
 /**
  * Parses a MapServer Mapfile to a JavaScript object.
  * @param {string} content Content of a MapServer Mapfile
+ * @param {string} symbolsPath path of the symbols.sym file if no symbolset is defined in the Mapfile.
  * @returns {Mapfile} the parsed Mapfile
  */
-export function parseMapfile(content: string): Mapfile {
+export function parseMapfile(content: string, symbolsPath: string): Mapfile {
   let result: any = parseContent(content);
 
   // add map bock for consistency if not exists
   result = 'map' in result ? result : { map: result };
 
   // resolve symbolset
-  const mapfile = resolveSymbolset(result as Mapfile);
+  const mapfile = resolveSymbolset(result as Mapfile, symbolsPath);
 
   return mapfile;
 }


### PR DESCRIPTION
https://jira.camptocamp.com/browse/GSSDI-27

If we use this lib not directly (I means, if the lib is in the nodes_modules), the current fallback path will be always false.
Now we can set the path to symbol file via the class:

const mapFileParser = MapfileStyleParser();
```
mapFileParser.symbolsPath = 'my/path/to/symbols.sym';
```
Default to `${process.cwd()}/symbols.sym` (process.cwd() => path of the folder where the node command executed.)

Or via the command line options:
```
mapfile-symbols-path=my/path/to/symbols.sym
```

This change was require to use geostyler-cli (see: #28 )