### PR TITLE
Sets outline and opacity defaults for polygon fill

### DIFF
--- a/data/mapfiles/polygon_simple_polygon_outline.map
+++ b/data/mapfiles/polygon_simple_polygon_outline.map
@@ -1,0 +1,19 @@
+LAYER
+    NAME "polygon_simple_polygon_outline"
+    TYPE POLYGON
+    DATA "../shapes/polygons.shp"
+    EXTENT -180 -90 180 90
+    METADATA
+      "wms_title" "polygon_simple_polygon_outline.map"
+      "wms_srs" "EPSG:4326"
+    END
+    CLASS
+      STYLE
+        COLOR 0 255 0
+      END
+      STYLE
+        OUTLINECOLOR 85 85 85
+        OUTLINEWIDTH 0.1
+      END
+    END
+END

--- a/data/styles/polygon_simple_polygon.ts
+++ b/data/styles/polygon_simple_polygon.ts
@@ -7,7 +7,9 @@ const polygonStyle: Style = {
     symbolizers: [{
       kind: 'Fill',
       color: '#00FF00',
-      outlineColor: '#555555'
+      fillOpacity: 1,
+      outlineColor: '#555555',
+      outlineOpacity: 1
     }]
   }]
 };

--- a/data/styles/polygon_simple_polygon_outline.ts
+++ b/data/styles/polygon_simple_polygon_outline.ts
@@ -1,0 +1,20 @@
+import { Style } from 'geostyler-style';
+
+const polygonStyle: Style = {
+  name: 'polygon_simple_polygon_outline',
+  rules: [
+    {
+      name: '',
+      symbolizers: [
+        { kind: 'Fill', outlineOpacity: 0, color: '#00FF00' },
+        {
+          kind: 'Fill',
+          outlineColor: '#555555',
+          fillOpacity: 0,
+          outlineWidth: 0.1
+        }
+      ]
+    }
+  ]
+};
+export default polygonStyle;

--- a/data/styles/polygon_simple_polygon_outline.ts
+++ b/data/styles/polygon_simple_polygon_outline.ts
@@ -6,12 +6,13 @@ const polygonStyle: Style = {
     {
       name: '',
       symbolizers: [
-        { kind: 'Fill', outlineOpacity: 0, color: '#00FF00' },
+        { kind: 'Fill', outlineOpacity: 0, color: '#00FF00', fillOpacity: 1 },
         {
           kind: 'Fill',
           outlineColor: '#555555',
           fillOpacity: 0,
-          outlineWidth: 0.1
+          outlineWidth: 0.1,
+          outlineOpacity: 1
         }
       ]
     }

--- a/src/MapfileStyleParser.spec.ts
+++ b/src/MapfileStyleParser.spec.ts
@@ -7,6 +7,7 @@ import { SldStyleParser } from 'geostyler-sld-parser';
 import point_simple_point from '../data/styles/point_simple_point';
 import line_simple_line from '../data/styles/line_simple_line';
 import polygon_simple_polygon from '../data/styles/polygon_simple_polygon';
+import polygon_simple_polygon_outline from '../data/styles/polygon_simple_polygon_outline';
 import raster_simple_raster from '../data/styles/raster_simple_raster';
 
 import point_simple_rgb_to_hex from '../data/styles/point_simple_rgb_to_hex';
@@ -67,6 +68,14 @@ describe('MapfileStyleParser implements StyleParser', () => {
       const geoStylerStyle = await styleParser.readStyle(mapfile);
       expect(geoStylerStyle).toBeDefined();
       expect(geoStylerStyle).toEqual(polygon_simple_polygon);
+    });
+
+    it('can read a simple MapFile PolygonSymbolizer with seperate outline', async () => {
+      expect.assertions(2);
+      const mapfile = fs.readFileSync( './data/mapfiles/polygon_simple_polygon_outline.map', 'utf8');
+      const geoStylerStyle = await styleParser.readStyle(mapfile);
+      expect(geoStylerStyle).toBeDefined();
+      expect(geoStylerStyle).toEqual(polygon_simple_polygon_outline);
     });
 
     it('can read a simple MapFile RasterSymbolizer', async () => {

--- a/src/MapfileStyleParser.ts
+++ b/src/MapfileStyleParser.ts
@@ -624,14 +624,25 @@ export class MapfileStyleParser implements StyleParser {
       fillSymbolizer.graphicFill = this.getPointSymbolizerFromMapfileStyle(mapfileStyle);
     }
 
+    if (mapfileStyle.color && !mapfileStyle.outlinecolor) {
+      fillSymbolizer.outlineOpacity = 0;
+    }
+
     if (mapfileStyle.outlinecolor) {
       fillSymbolizer.outlineColor = isHex(mapfileStyle.outlinecolor)
         ? mapfileStyle.outlinecolor
         : rgbToHex(mapfileStyle.outlinecolor);
+
+      if (mapfileStyle.width) {
+        fillSymbolizer.outlineWidth = mapfileStyle.width;
+      }
+      if (!mapfileStyle.color) {
+        fillSymbolizer.fillOpacity = 0;
+      }
     }
 
     if (mapfileStyle.outlinewidth) {
-      fillSymbolizer.outlineWidth = mapfileStyle.outlinewidth;
+      fillSymbolizer.outlineWidth = parseFloat(mapfileStyle.outlinewidth as unknown as string);
     }
 
     if (mapfileStyle.opacity) {

--- a/src/MapfileStyleParser.ts
+++ b/src/MapfileStyleParser.ts
@@ -625,31 +625,25 @@ export class MapfileStyleParser implements StyleParser {
     }
 
     if (mapfileStyle.color) {
-      fillSymbolizer.fillOpacity = mapfileStyle.opacity / 100 || 1;
-
-      if (!mapfileStyle.outlinecolor) {
-        fillSymbolizer.outlineOpacity = 0;
-      } else {
-        fillSymbolizer.outlineOpacity = mapfileStyle.opacity / 100 || 1;
-      }
+      fillSymbolizer.fillOpacity = mapfileStyle.opacity !== undefined ? mapfileStyle.opacity / 100 : 1;
+    } else {
+      fillSymbolizer.fillOpacity = 0;
     }
 
     if (mapfileStyle.outlinecolor) {
-      fillSymbolizer.outlineOpacity = mapfileStyle.opacity / 100 || 1;
+      fillSymbolizer.outlineOpacity = mapfileStyle.opacity !== undefined ? mapfileStyle.opacity / 100 : 1;
       fillSymbolizer.outlineColor = isHex(mapfileStyle.outlinecolor)
         ? mapfileStyle.outlinecolor
         : rgbToHex(mapfileStyle.outlinecolor);
 
-      if (mapfileStyle.width) {
+      if (mapfileStyle.width !== undefined) {
         fillSymbolizer.outlineWidth = mapfileStyle.width;
       }
-
-      if (!mapfileStyle.color) {
-        fillSymbolizer.fillOpacity = 0;
-      }
+    } else {
+      fillSymbolizer.outlineOpacity = 0;
     }
 
-    if (mapfileStyle.outlinewidth) {
+    if (mapfileStyle.outlinewidth !== undefined) {
       fillSymbolizer.outlineWidth = parseFloat(mapfileStyle.outlinewidth as unknown as string);
     }
 

--- a/src/MapfileStyleParser.ts
+++ b/src/MapfileStyleParser.ts
@@ -624,11 +624,18 @@ export class MapfileStyleParser implements StyleParser {
       fillSymbolizer.graphicFill = this.getPointSymbolizerFromMapfileStyle(mapfileStyle);
     }
 
-    if (mapfileStyle.color && !mapfileStyle.outlinecolor) {
-      fillSymbolizer.outlineOpacity = 0;
+    if (mapfileStyle.color) {
+      fillSymbolizer.fillOpacity = mapfileStyle.opacity / 100 || 1;
+
+      if (!mapfileStyle.outlinecolor) {
+        fillSymbolizer.outlineOpacity = 0;
+      } else {
+        fillSymbolizer.outlineOpacity = mapfileStyle.opacity / 100 || 1;
+      }
     }
 
     if (mapfileStyle.outlinecolor) {
+      fillSymbolizer.outlineOpacity = mapfileStyle.opacity / 100 || 1;
       fillSymbolizer.outlineColor = isHex(mapfileStyle.outlinecolor)
         ? mapfileStyle.outlinecolor
         : rgbToHex(mapfileStyle.outlinecolor);
@@ -636,6 +643,7 @@ export class MapfileStyleParser implements StyleParser {
       if (mapfileStyle.width) {
         fillSymbolizer.outlineWidth = mapfileStyle.width;
       }
+
       if (!mapfileStyle.color) {
         fillSymbolizer.fillOpacity = 0;
       }
@@ -643,10 +651,6 @@ export class MapfileStyleParser implements StyleParser {
 
     if (mapfileStyle.outlinewidth) {
       fillSymbolizer.outlineWidth = parseFloat(mapfileStyle.outlinewidth as unknown as string);
-    }
-
-    if (mapfileStyle.opacity) {
-      fillSymbolizer.outlineOpacity = mapfileStyle.opacity / 100;
     }
 
     if (mapfileStyle.pattern) {
@@ -838,7 +842,6 @@ export class MapfileStyleParser implements StyleParser {
         this.checkWarnDropRule('MAXSCALEDENOM', 'LABEL', mapfileLabel.maxscaledenom);
       });
     }
-
     return symbolizers;
   }
 


### PR DESCRIPTION
This MR

- uses `mapfileStyle.width` (if defined) as `outlineWidth`
- sets default values for outlineOpacity and opacity
    - depending on `mapfileStyle.color` and `mapfileStyle.outlineColor` the corresponding opacity values (`fillOpacity` and `outlineOpacity`) are set to the defined value or a default value
- provides a new test case for polygons defined with separate styles for fill and outline values

@KaiVolland @jansule please review